### PR TITLE
Make zpm-generate-ui compatible with both older and newer version of package manager

### DIFF
--- a/module.xml
+++ b/module.xml
@@ -23,6 +23,7 @@
     <Invokes>
      <Invoke Class="apptools.lte.zapm" Method="init"></Invoke>
     </Invokes>
+	<Resource Name="apptools.lte.compat.CLS"/>
 	<Resource Name="apptools.lte.zapm.CLS"/>
 	<Resource Name="apptools.lte.resources.CLS"/>
     </Module>

--- a/src/cls/apptools/lte/compat.cls
+++ b/src/cls/apptools/lte/compat.cls
@@ -1,0 +1,32 @@
+Class apptools.lte.compat
+{
+
+ClassMethod GetZpmClass(pNew As %String, pOld As %String) As %String [ Internal ]
+{
+	If ##class(%Dictionary.ClassDefinition).%ExistsId(pNew) {
+		Return pNew
+	} ElseIf ##class(%Dictionary.ClassDefinition).%ExistsId(pOld) {
+		Return pOld
+	} Else {
+        zw pNew, pOld
+        Break
+		Throw ##class(%Exception.General).%New("IPM is not installed in namespace "_$NAMESPACE)
+	}
+}
+
+ClassMethod GetZpmMainClass() As %String [ Internal ]
+{
+	Return ..GetZpmClass("%IPM.Main", "%ZPM.PackageManager")
+}
+
+ClassMethod GetZpmModuleClass() As %String [ Internal ]
+{
+	Return ..GetZpmClass("%IPM.Module.Storage", "%ZPM.PackageManager.Developer.Module")
+}
+
+ClassMethod GetZpmDefinitionClass() As %String [ Internal ]
+{
+    Return ..GetZpmClass("%IPM.Repo.Definition", "%ZPM.PackageManager.Client.ServerDefinition")
+}
+
+}

--- a/src/cls/apptools/lte/resources.cls
+++ b/src/cls/apptools/lte/resources.cls
@@ -1,7 +1,7 @@
 Include apptools.core
 
 /// Resources utilities for ZPM
-Class apptools.lte.resources [ Abstract, DependsOn = apptools.core.msg ]
+Class apptools.lte.resources extends apptools.lte.compat [ Abstract, DependsOn = apptools.core.msg ]
 {
 
 /// Default name new packet
@@ -37,7 +37,7 @@ ClassMethod UiSaveRepo(Par = "") As %Status
 			set st=##class(%ZAPM.ext.zapp).prompt("newdb "_i)
 		}
 		elseif mode="install" {
-			set st=##class(%ZPM.PackageManager).Shell("install "_i)
+			set st=$CLASSMETHOD(..GetZpmMainClass(), "Shell", "install "_i)
 		}
 		write "</pre>"
 		if 'st write $$$appError($System.Status.GetErrorText(st))
@@ -142,14 +142,14 @@ ClassMethod UiSaveResources(Par = "") As %Status
 	}
 	if mode="load" { //LOAD
 		write "<pre>"
-		set st=##class(%ZPM.PackageManager).Shell("load "_WorkDirPacket)
+		set st=$CLASSMETHOD(..GetZpmMainClass(), "Shell", "load "_WorkDirPacket)
 		write "</pre>"
 	}
 	elseif mode="package" { //PACKAGE
 		set cmd="package -p "_WorkDirPacket_" "_namezpm
 		write cmd
 		write "<pre>"
-		set st=##class(%ZPM.PackageManager).Shell(cmd)
+		set st=$CLASSMETHOD(..GetZpmMainClass(), "Shell", cmd)
 		write "</pre>"
 		set filetgz=WorkDirPacket_".tgz"
 		if ##class(%File).Exists(filetgz) {
@@ -310,7 +310,7 @@ ClassMethod UiMatrixResources(key, divId, ns, mode, zpmname, GN, blockui = 1) As
 	;-----------------
 	set gnpro=$na(@GN@("prototype",ns))
 	write $$$appInputHidden(divId_"ModeSet","",mode)
-	If mode="edit",##class(%ZPM.PackageManager.Developer.Module).NameExists(zpmname) { ;-------------------
+	If mode="edit",$CLASSMETHOD(..GetZpmModuleClass(), "NameExists", zpmname) { ;-------------------
 		if '..GetResourcesFromZpm(zpmname,.Module,.Res) quit $$$OK
 		do ##class(%ZAPM.ext.zpm).GetListModule(ns,.List,0)
 		set dirroot=$lg($G(List(zpmname,"L")),3)
@@ -432,7 +432,7 @@ ClassMethod ResourceWinOpen(Par = "")
 
 ClassMethod GetResourcesFromZpm(zpmname, ByRef Module, ByRef Res) As %Status
 {
-	Set Module = ##class(%ZPM.PackageManager.Developer.Module).NameOpen(zpmname,,.tSC)
+	Set Module = $CLASSMETHOD(..GetZpmModuleClass(), "NameOpen", zpmname, , .tSC)
 	If $$$ISERR(tSC) {	Quit tSC }
 	set lo=Module.CalculatedResourcesGet()
 	set debug=0 ;
@@ -482,8 +482,13 @@ ClassMethod GetZPMRepo(List, FindMask = "") As %Status
 	
 	do ##class(%ZAPM.ext.zpm).GetVerZpm(.IsHspm,.RepoFieldName)	
 	set where="(1=1)"
+	If $EXTRACT(..GetZpmMainClass(), 1, 4) = "%IPM" {
+		set tCall = "%IPM_Utils.Module_GetModuleList"
+	} Else {
+		set tCall = "%ZPM_PackageManager_Developer.Utils_GetModuleList"
+	}
 	if "*"'[FindMask set where="name like '"_$replace(FindMask,"*","%")_"'" 
-	Set tQuery = "select Name, Version, "_RepoFieldName_", Description from %ZPM_PackageManager_Developer.Utils_GetModuleList('registry') WHERE "_where
+	Set tQuery = "select Name, Version, "_RepoFieldName_", Description from "_tCall_"('registry') WHERE "_where
 	;w !,tQuery
 	Set tRes = ##class(%SQL.Statement).%ExecDirect(,tQuery)
 	
@@ -503,12 +508,12 @@ ClassMethod GetZpmNamespaces(ByRef out, text = "", ByRef nspace)
 {
 	new $Namespace
 	Set currentns=$Namespace
-	Do ##class(%ZPM.PackageManager).GetListNamespace(.namespace)
+	Do $CLASSMETHOD(..GetZpmMainClass(), "GetListNamespace", .namespace)
 	Set ns=""
 	For { set ns=$Order(namespace(ns)) Quit:ns=""
 		Set $Namespace=ns
 		Kill list
-		Do ##class(%ZPM.PackageManager).GetListModules("",.list)
+		Do $CLASSMETHOD(..GetZpmMainClass(), "GetListModules", "", .list)
 		;w !,ns zw list
 		If $D(list) {
 			Set module=""

--- a/src/cls/apptools/lte/zapm.cls
+++ b/src/cls/apptools/lte/zapm.cls
@@ -1,7 +1,7 @@
 Include apptools.core
 
 /// http://localhost:52773/apptoolsrest/a/info
-Class apptools.lte.zapm Extends apptools.lte.adminTabs [ ClassType = "", DependsOn = apptools.core.msg, ProcedureBlock ]
+Class apptools.lte.zapm Extends (apptools.lte.adminTabs, apptools.lte.compat) [ ClassType = "", DependsOn = apptools.core.msg, ProcedureBlock ]
 {
 
 /// Application title
@@ -256,7 +256,7 @@ ClassMethod NSpaceResult(Par = "") As %Status
 		if ##class(apptools.lte.zapm).PrivateRepo(,.currepo) {
 			set head="Publish package into '"_$G(currepo(0))_"'"
 			write head_"<br><pre>"
-			set st=##class(%ZPM.PackageManager).Shell("publish "_zpmname)
+			set st=$CLASSMETHOD(..GetZpmMainClass(), "Shell", "publish "_zpmname)
 			write "</pre>"
 			if 'st write $$$appError($System.Status.GetErrorText(st))
 			else  write $$$appMsg("Done")
@@ -291,7 +291,7 @@ ClassMethod NSpaceResult(Par = "") As %Status
 	elseif mode="yes" {
 		set head="Uninstall packages '"_zpmname_"' from current namespace '"_ns_"' "
 		write head_"<br><pre>"
-		set st=##class(%ZPM.PackageManager).Shell("uninstall "_zpmname)
+		set st=$CLASSMETHOD(..GetZpmMainClass(), "Shell", "uninstall "_zpmname)
 		write "</pre>"
 		if 'st write $$$appError($System.Status.GetErrorText(st))
 		else  write $$$appMsg("Done")
@@ -454,13 +454,14 @@ ClassMethod OptionsResult(Par = "") As %Status
 /// write ##class(apptools.lte.zapm).PrivateRepo(,.r)
 ClassMethod PrivateRepo(serverClassList = "", ByRef repo) As %Status
 {
-    Set tRes = ##class(%ZPM.PackageManager.Client.ServerDefinition).ListFunc()
+	set tDefinitionClass = ..GetZpmDefinitionClass()
+    Set tRes = $CLASSMETHOD(tDefinitionClass, "ListFunc")
     $$$ThrowSQLIfError(tRes.%SQLCODE,tRes.%Message)
 	Set tDisplayCount = 0
 	set yes=0
 	While tRes.%Next(.tSC) {
 			$$$ThrowOnError(tSC)
-			Set tRepository = ##class(%ZPM.PackageManager.Client.ServerDefinition).ServerDefinitionKeyOpen(tRes.%Get("Name"),,.tSC)
+			Set tRepository = $CLASSMETHOD(%ZPM.PackageManager.Client.ServerDefinition, "ServerDefinitionKeyOpen", tRes.%Get("Name"),,.tSC)
 			$$$ThrowOnError(tSC)
 			If serverClassList = "" || ($ListFind(serverClassList, $Classname(tRepository))) {
 				;Do tRepository.Display()
@@ -482,7 +483,7 @@ ClassMethod init(installall = 0) As %Status
  new $namespace
  set $namespace="%SYS"
 	if '..IsInstallzpm("zapm") {
-		do ##class(%ZPM.PackageManager).Shell("install zapm")
+		do $CLASSMETHOD(..GetZpmMainClass(), "Shell", "install zapm")
 	}
  set $namespace=curna
  write !,"Load for demo "_##class(apptools.core.net).GetURI(.prop)_"/apptoolsrest/a/zapm"
@@ -505,13 +506,13 @@ ClassMethod init(installall = 0) As %Status
 			 for i="zpm-registry","zpmshow" {
 			 	set st=##class(%ZAPM.ext.zapp).prompt("newdb "_i)
 			 }
-		    do:'..IsInstallzpm("fileserver") ##class(%ZPM.PackageManager).Shell("load https://github.com/SergeyMi37/Cache-FileServer")
+		    do:'..IsInstallzpm("fileserver") $CLASSMETHOD(..GetZpmMainClass(), "Shell", "load https://github.com/SergeyMi37/Cache-FileServer")
 		 }
 		 else {  ;install zpm modules for Docker -------------------------------
 			 for i="zpm-registry","zpmshow" {
 			 	set st=##class(%ZAPM.ext.zapp).prompt("newdb "_i)
 			 }
-		    do:'..IsInstallzpm("fileserver") ##class(%ZPM.PackageManager).Shell("load https://github.com/SergeyMi37/Cache-FileServer")
+		    do:'..IsInstallzpm("fileserver") $CLASSMETHOD(..GetZpmMainClass(), "Shell", "load https://github.com/SergeyMi37/Cache-FileServer")
 		 }
 		}
 		else {  //just linux without docker
@@ -540,7 +541,7 @@ ClassMethod init(installall = 0) As %Status
 /// write ##class(appmsw.python.util).IsInstallzpm("exchange-rate-cbrf")
 ClassMethod IsInstallzpm(modulename, ns = {$namespace}) As %String
 {
-	do ##class(%ZPM.PackageManager).GetListModule(ns,.list)
+	do $CLASSMETHOD(..GetZpmMainClass(), "GetListModule", ns,.list)
 	;zw list
 	quit $DATA(list(modulename))
 }


### PR DESCRIPTION
Hi @SergeyMi37 , 

## Background

InterSystems is planning to release a new version of IPM (previously known as ZPM). We made some breaking changes in this release, including renaming of packages and classes. Since your package references one or more of such renamed classes, we would like to help you update your package so that it's compatible with both new and old package managers.

## Testing

### Older Versions

You can test that this PR works on older versions (ZPM v0.7.1 and earlier) by running

```bash
zpm "load https://github.com/isc-shuliu/zpm-generate-ui"
```

### Newer Versions

You can also test the PR on our unreleased new package manager by running it in a container

```bash
git clone https://github.com/intersystems/ipm
cd ipm
git checkout v1
docker compose up -d
docker exec -it ipm-sandbox-1 /bin/bash
```

Then, in the docker container, run `iris session IRIS` to enter iris shell
```
do $System.OBJ.Load("/home/irisowner/zpm/preload/cls/IPM/Installer.cls", "ck")
do ##class(IPM.Installer).setup("/home/irisowner/zpm/")
zpm "repo -delete-all"
zpm "repo -reset-defaults"
```

Also, since the newer version of IPM is installed on a per-namespace level, you may want to enable package mapping if your code touches other namespaces.

Finally, you can run 

```
zpm "load https://github.com/isc-shuliu/zpm-generate-ui"
```

to verify successful installation. 



Let me know if you have any questions!